### PR TITLE
#552

### DIFF
--- a/src/main/groovy/au/org/ala/biocache/hubs/AdvancedSearchParams.groovy
+++ b/src/main/groovy/au/org/ala/biocache/hubs/AdvancedSearchParams.groovy
@@ -140,7 +140,7 @@ class AdvancedSearchParams implements Validateable {
         if (institution_collection) {
 //            String label = (StringUtils.startsWith(institution_collection, "in")) ? "institution_uid" : "collection_uid"
             String label = "institution_code"
-            queryItems.add(label + ":" + institution_collection)
+            queryItems.add(label + ":\"" + institution_collection + "\"")
         }
 
         if (start_date || end_date) {


### PR DESCRIPTION
- add quote around the institution search string as if there are whitespaces in the name then the query is not strict enough